### PR TITLE
Сделал private event - /users/{userId}/events/{eventId}.

### DIFF
--- a/ewm-service/src/main/java/ru/practicum/events/EventsPrivateController.java
+++ b/ewm-service/src/main/java/ru/practicum/events/EventsPrivateController.java
@@ -1,6 +1,7 @@
 package ru.practicum.events;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +10,11 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.practicum.events.dto.EventFullDto;
 import ru.practicum.events.dto.NewEventDto;
+import ru.practicum.events.dto.UpdateEventUserRequest;
 import ru.practicum.events.service.EventService;
 import ru.practicum.validation.Marker;
 
+import static ru.practicum.util.Constants.PATH_VARIABLE_EVENT_ID;
 import static ru.practicum.util.Constants.PATH_VARIABLE_USER_ID;
 
 @Validated
@@ -30,10 +33,21 @@ public class EventsPrivateController {
     @PostMapping
     @Validated(Marker.OnCreate.class)
     @ResponseStatus(HttpStatus.CREATED)
-    EventFullDto add(@PathVariable(name = PATH_VARIABLE_USER_ID) Long userId,
+    EventFullDto add(@PathVariable(name = PATH_VARIABLE_USER_ID) @Positive(groups = Marker.OnCreate.class) Long userId,
                      @RequestBody @Valid NewEventDto newEventDto) {
         log.info("Получен запрос: Добавить новое событие {}", newEventDto.getAnnotation());
 
         return eventService.add(userId, newEventDto);
+    }
+
+    @PatchMapping("/{eventId}")
+    @Validated(Marker.OnUpdate.class)
+    @ResponseStatus(HttpStatus.OK)
+    EventFullDto update(@PathVariable(name = PATH_VARIABLE_USER_ID) @Positive(groups = Marker.OnUpdate.class) Long userId,
+                        @PathVariable(name = PATH_VARIABLE_EVENT_ID) @Positive(groups = Marker.OnUpdate.class) Long eventId,
+                        @RequestBody @Valid UpdateEventUserRequest updateEventUserRequest) {
+        log.info("Получен запрос: Обновить событие пользователем {}", updateEventUserRequest.getAnnotation());
+
+        return eventService.update(userId, eventId, updateEventUserRequest);
     }
 }

--- a/ewm-service/src/main/java/ru/practicum/events/ExceptionHandler/GlobalExceptionHandler.java
+++ b/ewm-service/src/main/java/ru/practicum/events/ExceptionHandler/GlobalExceptionHandler.java
@@ -4,7 +4,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ru.practicum.ewm.handler.exception.ForbiddenOperationException;
 import ru.practicum.exception.ConflictException;
 import ru.practicum.exception.NotFoundException;
 import ru.practicum.exception.ValidationException;
@@ -44,6 +46,10 @@ public class GlobalExceptionHandler {
         ApiError apiError = new ApiError("Bad Request", "Validation failed", HttpStatus.BAD_REQUEST, errors);
         return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(ForbiddenOperationException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ApiError handleForbiddenOperationException(ForbiddenOperationException ex) {
+        return new ApiError("For the requested operation the conditions are not met.", ex.getMessage(), HttpStatus.FORBIDDEN);
+    }
 }
-
-

--- a/ewm-service/src/main/java/ru/practicum/events/convertors/StringToEventStateConverter.java
+++ b/ewm-service/src/main/java/ru/practicum/events/convertors/StringToEventStateConverter.java
@@ -1,0 +1,27 @@
+package ru.practicum.events.convertors;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import ru.practicum.events.enums.EventState;
+import ru.practicum.ewm.handler.exception.ForbiddenOperationException;
+
+import static ru.practicum.util.Constants.VALUE_CANCEL_REVIEW;
+import static ru.practicum.util.Constants.VALUE_SEND_TO_REVIEW;
+
+@Component
+public class StringToEventStateConverter extends StdConverter<String, EventState> {
+    private static final Logger log = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(StringToEventStateConverter.class);
+
+    @Override
+    public EventState convert(String value) {
+        if (value.equals(VALUE_SEND_TO_REVIEW)) {
+            return EventState.PENDING;
+        } else if (value.equals(VALUE_CANCEL_REVIEW)) {
+            return EventState.CANCELED;
+        } else {
+            throw new ForbiddenOperationException("Only pending or canceled events can be changed.", log);
+        }
+    }
+}

--- a/ewm-service/src/main/java/ru/practicum/events/dto/UpdateEventUserRequest.java
+++ b/ewm-service/src/main/java/ru/practicum/events/dto/UpdateEventUserRequest.java
@@ -1,0 +1,57 @@
+package ru.practicum.events.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import ru.practicum.events.convertors.StringToEventStateConverter;
+import ru.practicum.events.enums.EventState;
+import ru.practicum.validation.EventDate;
+import ru.practicum.validation.Marker;
+
+import java.time.LocalDateTime;
+
+import static ru.practicum.util.Constants.*;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UpdateEventUserRequest {
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Size(min = LENGTH_ANNOTATION_EVENT_MIN, max = LENGTH_ANNOTATION_EVENT_MAX, message = "Длина краткого описания события не прошла валидацию.", groups = Marker.OnUpdate.class)
+    String annotation;
+
+    @JsonProperty(value = "category", access = JsonProperty.Access.WRITE_ONLY)
+    Long categoryId;  // категория к которой относится событие
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Size(min = LENGTH_DESCRIPTION_EVENT_MIN, max = LENGTH_DESCRIPTION_EVENT_MAX, message = "Длина описания события не прошла валидацию.", groups = Marker.OnUpdate.class)
+    String description;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @JsonFormat(pattern = PATTERN_FORMATE_DATE)
+    @EventDate(groups = Marker.OnUpdate.class)
+    LocalDateTime eventDate;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    LocationDto location;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    Boolean paid;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    Long participantLimit;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    Boolean requestModeration;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @JsonDeserialize(converter = StringToEventStateConverter.class)
+    EventState stateAction;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Size(min = LENGTH_TITLE_EVENT_MIN, max = LENGTH_TITLE_EVENT_MAX, message = "Длина заголовка события не прошла валидацию.", groups = Marker.OnUpdate.class)
+    String title;
+}

--- a/ewm-service/src/main/java/ru/practicum/events/mapper/EventMapperStruct.java
+++ b/ewm-service/src/main/java/ru/practicum/events/mapper/EventMapperStruct.java
@@ -8,6 +8,7 @@ import org.mapstruct.factory.Mappers;
 import ru.practicum.category.mapper.CategoryMapper;
 import ru.practicum.category.model.Category;
 import ru.practicum.events.dto.NewEventDto;
+import ru.practicum.events.dto.UpdateEventUserRequest;
 import ru.practicum.events.enums.EventState;
 import ru.practicum.events.model.Event;
 import ru.practicum.ewm.user.model.User;
@@ -37,4 +38,11 @@ public interface EventMapperStruct {
     default LocalDateTime getCreatedOn(NewEventDto newEventDto) {
         return LocalDateTime.now();
     }
+
+    @Mapping(source = "eventId", target = "id")
+    @Mapping(source = "updateEventUserRequest.location.lat", target = "locationLat")
+    @Mapping(source = "updateEventUserRequest.location.lon", target = "locationLon")
+    @Mapping(source = "user", target = "initiator")
+    @Mapping(source = "updateEventUserRequest.stateAction", target = "state")
+    Event toEvent(User user, Long eventId, UpdateEventUserRequest updateEventUserRequest);
 }

--- a/ewm-service/src/main/java/ru/practicum/events/model/Event.java
+++ b/ewm-service/src/main/java/ru/practicum/events/model/Event.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import ru.practicum.category.model.Category;
 import ru.practicum.events.enums.EventState;
 import ru.practicum.ewm.user.model.User;
+import ru.practicum.validation.FieldDescription;
 
 import java.time.LocalDateTime;
 
@@ -30,13 +31,16 @@ import java.time.LocalDateTime;
 public class Event {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @FieldDescription(value = "Уникальный идентификатор собятия", changeByCopy = false)
     private Long id;
 
     @Column(nullable = false, length = 2000)
+    @FieldDescription(value = "Аннотация")
     private String annotation;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
+    @FieldDescription(value = "Категория события")
     private Category category;
 
     @Column(name = "confirmed_requests")
@@ -46,38 +50,48 @@ public class Event {
     private LocalDateTime createdOn = LocalDateTime.now();
 
     @Column(nullable = false, length = 7000)
+    @FieldDescription(value = "Описание")
     private String description;
 
     @Column(name = "event_date", nullable = false)
+    @FieldDescription(value = "Дата проведения")
     private LocalDateTime eventDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "initiator_id", nullable = false)
+    @FieldDescription(value = "Пользователь")
     private User initiator;
 
     @Column(name = "location_lat")
+    @FieldDescription(value = "Д")
     private Float locationLat;
 
     @Column(name = "location_lon")
+    @FieldDescription(value = "Ш")
     private Float locationLon;
 
     @Column(nullable = false)
+    @FieldDescription(value = "Утверждение")
     private Boolean paid = false;
 
     @Column(name = "participant_limit")
+    @FieldDescription(value = "Ограничение по колву")
     private Integer participantLimit = 0;
 
     @Column(name = "published_on")
     private LocalDateTime publishedOn;
 
     @Column(name = "request_moderation")
+    @FieldDescription(value = "Модерация")
     private Boolean requestModeration = true;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @FieldDescription(value = "Состояние")
     private EventState state = EventState.PENDING;
 
     @Column(nullable = false, length = 120)
+    @FieldDescription(value = "Заголовок")
     private String title;
 
     private Long views = 0L;

--- a/ewm-service/src/main/java/ru/practicum/events/service/EventService.java
+++ b/ewm-service/src/main/java/ru/practicum/events/service/EventService.java
@@ -3,6 +3,7 @@ package ru.practicum.events.service;
 import ru.practicum.events.dto.EventFullDto;
 import ru.practicum.events.dto.NewEventDto;
 import ru.practicum.events.dto.UpdateEventAdminRequest;
+import ru.practicum.events.dto.UpdateEventUserRequest;
 import ru.practicum.events.params.AdminEventParams;
 
 import java.util.List;
@@ -13,4 +14,6 @@ public interface EventService {
     EventFullDto updateEventByAdmin(Long eventId, UpdateEventAdminRequest dto);
 
     public EventFullDto add(Long userId, NewEventDto newEventDto);
+
+    public EventFullDto update(Long userId, Long eventId, UpdateEventUserRequest updateEventUserRequest);
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/handler/exception/ForbiddenOperationException.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/handler/exception/ForbiddenOperationException.java
@@ -1,7 +1,14 @@
 package ru.practicum.ewm.handler.exception;
 
+import org.slf4j.Logger;
+
 public class ForbiddenOperationException extends RuntimeException {
     public ForbiddenOperationException(String message) {
         super(message);
+    }
+
+    public ForbiddenOperationException(String message, Logger logger) {
+        this(message);
+        logger.error(message);
     }
 }

--- a/ewm-service/src/main/java/ru/practicum/util/Constants.java
+++ b/ewm-service/src/main/java/ru/practicum/util/Constants.java
@@ -8,6 +8,7 @@ public final class Constants {
     public static final int LENGTH_NAME_CATEGORY_MAX = 50;
     public static final String PATH_VARIABLE_ID = "id";
     public static final String PATH_VARIABLE_USER_ID = "userId";
+    public static final String PATH_VARIABLE_EVENT_ID = "eventId";
     public static final int LENGTH_DESCRIPTION_EVENT_MIN = 20;
     public static final int LENGTH_DESCRIPTION_EVENT_MAX = 7000;
     public static final int OFFSET_EVENT_DATE = 7200;
@@ -16,4 +17,6 @@ public final class Constants {
     public static final int LENGTH_ANNOTATION_EVENT_MIN = 20;
     public static final int LENGTH_ANNOTATION_EVENT_MAX = 2000;
     public static final String PATTERN_FORMATE_DATE = "yyyy-MM-dd HH:mm:ss";
+    public static final String VALUE_SEND_TO_REVIEW = "SEND_TO_REVIEW";
+    public static final String VALUE_CANCEL_REVIEW = "CANCEL_REVIEW";
 }


### PR DESCRIPTION
## Summary by Sourcery

Add private user event update functionality, including a PATCH endpoint, DTO with validation, service and mapper logic, custom state conversion, and exception handling

New Features:
- Add PATCH /users/{userId}/events/{eventId} endpoint for users to update their events
- Introduce UpdateEventUserRequest DTO with validation rules for partial event updates
- Implement EventService.update and EventServiceImpl logic to apply and persist user-initiated event modifications
- Extend EventMapperStruct with mapping from UpdateEventUserRequest to Event entity
- Add StringToEventStateConverter to translate stateAction values and reject invalid transitions
- Introduce ForbiddenOperationException and configure GlobalExceptionHandler to return 403 on forbidden operations

Enhancements:
- Annotate Event entity fields with @FieldDescription for documentation
- Define new constants for PATH_VARIABLE_EVENT_ID and state action values in Constants