### PR TITLE
правки

### DIFF
--- a/ewm-service/src/main/java/ru/practicum/compilations/mapper/CompilationMapper.java
+++ b/ewm-service/src/main/java/ru/practicum/compilations/mapper/CompilationMapper.java
@@ -1,5 +1,7 @@
 package ru.practicum.compilations.mapper;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import ru.practicum.compilations.dto.CompilationDto;
 import ru.practicum.compilations.dto.NewCompilationDto;
 import ru.practicum.compilations.dto.UpdateCompilationRequest;
@@ -12,9 +14,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Component
+@RequiredArgsConstructor
 public class CompilationMapper {
-    private static EventMapper eventMapper;
-    public static Compilation toCompilation(NewCompilationDto dto, Set<Event> events) {
+    private final EventMapper eventMapper;
+
+    public Compilation toCompilation(NewCompilationDto dto, Set<Event> events) {
         return Compilation.builder()
                 .pinned(dto.getPinned() != null ? dto.getPinned() : false)
                 .title(dto.getTitle())
@@ -22,7 +27,7 @@ public class CompilationMapper {
                 .build();
     }
 
-    public static CompilationDto toCompilationDto(Compilation compilation) {
+    public CompilationDto toCompilationDto(Compilation compilation) {
         List<EventShortDto> eventDtos = compilation.getEvents().stream()
                 .map(eventMapper::toEventShortDto)
                 .collect(Collectors.toList());

--- a/ewm-service/src/main/java/ru/practicum/compilations/service/CompilationService.java
+++ b/ewm-service/src/main/java/ru/practicum/compilations/service/CompilationService.java
@@ -17,4 +17,5 @@ public interface CompilationService {
     CompilationDto addCompilation(NewCompilationDto dto);
     CompilationDto updateCompilation(Long compId, UpdateCompilationRequest dto);
     void removeCompilation(Long compId);
+
 }


### PR DESCRIPTION
## Summary by Sourcery

Convert CompilationMapper to a Spring component and inject it into CompilationServiceImpl; refactor mapping calls to use the injected mapper and enhance event retrieval by filtering nulls/duplicates and throwing NotFoundException when requested events are missing.

Bug Fixes:
- Improve event retrieval logic to filter null and duplicate IDs and throw NotFoundException when some requested events are not found

Enhancements:
- Convert CompilationMapper to a Spring @Component with injected EventMapper and instance mapping methods
- Inject CompilationMapper into CompilationServiceImpl and replace static mapper calls with instance calls